### PR TITLE
improving figure saving

### DIFF
--- a/code/bubble.py
+++ b/code/bubble.py
@@ -2,7 +2,7 @@
 Example of matplotlib colormaps
 http://matplotlib.org/api/colors_api.html
 """
-
+import file_handler
 import numpy as np
 
 import matplotlib
@@ -25,9 +25,12 @@ cmap = mcm.spring
 norm = mcolors.BoundaryNorm(np.arange(11), cmap.N)
 
 ax = fig.add_subplot(1,1,1)
-scat = ax.scatter(a,b,c=c, s=(d+10)*50, 
+scat = ax.scatter(a,b,c=c, s=(d+10)*50,
                   cmap=cmap,norm=norm)
 fig.colorbar(scat, ax=ax, fraction=.45)
 
-canvas.print_figure('../figures/cmapbubble.png', 
-		facecolor='lightgray')
+image_name = "cmapbubble.png"
+file_name = file_handler.get_file_name(image_name)
+with open (file_name, 'w') as f:
+    canvas.print_figure(f,
+        facecolor='lightgray')

--- a/code/file_handler.py
+++ b/code/file_handler.py
@@ -1,0 +1,18 @@
+import errno
+import os
+
+def get_file_name(image_name):
+    current_dir = os.path.dirname(__file__)
+    figures_dir = os.path.join(
+    current_dir, "../figures")
+    try:
+        os.makedirs(os.path.abspath(figures_dir))
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(
+            path):
+            pass
+        else:
+            raise
+    file_name = os.path.join(
+    figures_dir, "cmapbubble.png")
+    return file_name


### PR DESCRIPTION
- added file_handler module to create the directory "figures" if it doesn't exist 
- code should also now work for folks on windows computers

Hi! I took your tutorial in 2014 and I wanted to send this off to a pylady in our group for reference. I know she is working on a windows computer so she would have trouble getting it to save the image without some fiddling. Currently, the file_handler import is only in the bubbles.py example. I can add it the to rest later and update this pull request if you find this helpful. 
